### PR TITLE
feat(http): implement request router

### DIFF
--- a/http/router.ts
+++ b/http/router.ts
@@ -1,0 +1,348 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import { ConnInfo, Handler } from "./native_server.ts";
+import { normalize } from "../path/posix.ts";
+import { Status, STATUS_TEXT } from "./http_status.ts";
+
+/**
+ * Thrown when providing an invalid route string to the Router.handle method.
+ */
+const ERROR_INVALID_ROUTE = new Deno.errors.Http("Invalid route");
+
+/**
+ * Retrieves the Host on which the URL is sought. For HTTP/1 (RFC 7230, section
+ * 5.4), this is either the value of the "Host" header or the host name given
+ * in the URL itself. For HTTP/2, it is the value of the ":authority" pseudo-
+ * header field.
+ *
+ * @param {Headers} headers The request headers.
+ * @param {URL} url The request url.
+ * @returns {string} The host.
+ * @private
+ */
+function _getHost(headers: Headers, { protocol, host }: URL): string {
+  // TODO: for HTTP/2 use the ":authority" pseudo-header.
+  const hostHeader = headers.get("host");
+
+  return hostHeader ? new URL(`${protocol}${hostHeader}`).host : host;
+}
+
+/**
+ * Retrieves the Hostname (Host without Port). For HTTP/1 (RFC 7230, section
+ * 5.4), this is either the value of the "Host" header or the host name given
+ * in the URL itself. For HTTP/2, it is the value of the ":authority" pseudo-
+ * header field.
+ *
+ * @param {Headers} headers The request headers.
+ * @param {URL} url The request url.
+ * @param {string} url.protocol The request protocol.
+ * @param {string} url.hostname The request hostname (request host without port).
+ * @returns {string} The hostname (host without port).
+ * @private
+ */
+function _getHostname(headers: Headers, { protocol, hostname }: URL) {
+  // TODO: for HTTP/2 use the ":authority" pseudo-header.
+  const hostHeader = headers.get("host");
+
+  return hostHeader ? new URL(`${protocol}${hostHeader}`).hostname : hostname;
+}
+
+/**
+ * Normalizes the request path.
+ *
+ * @param {string} pathname The request path.
+ * @returns {string} The normalized path.
+ */
+function _getNormalizedPath(pathname: string): string {
+  if (pathname === "") {
+    return "/";
+  }
+
+  const path = pathname[0] === "/" ? pathname : `/${pathname}`;
+
+  return normalize(path);
+}
+
+/**
+ * Constructs a "Redirect" handler for the provided destination url and status.
+ *
+ * @param {URL} url The request URL.
+ * @param {Status} status The redirect status code.
+ * @returns {Handler} A "Redirect" handler.
+ */
+function _redirectHandler(url: URL, status: Status): Handler {
+  return function _redirect(): Response {
+    const headers = new Headers({ location: url.toString() });
+
+    return new Response(null, { status, headers });
+  };
+}
+
+/**
+ * Constructs a "Not Found" handler which will response with a 404 "Not Found"
+ * response and status code.
+ *
+ * @returns {Handler} A "Not Found" handler.
+ */
+function _notFoundHandler(): Handler {
+  const status = Status.NotFound;
+  const statusText = STATUS_TEXT.get(status);
+  const headers = new Headers({
+    "content-type": "text/plain; charset=utf-8",
+    "x-content-type-options": "nosniff",
+  });
+
+  return function _notFound(): Response {
+    return new Response(statusText, { headers, status });
+  };
+}
+
+/**
+ * Router is a HTTP request router.
+ *
+ * It matches the URL of each incoming request against a map of registered
+ * routes and executes the associated handler.
+ *
+ * Routes can be fixed, rooted paths (e.g. `"/index.html"`) or rooted subtrees
+ * (e.g. `"/public/"`). Longer routes take precedent over shorter ones. This
+ * means if there are registered handlers for both `"/public/"` and
+ * `"/public/images/"`, the latter will be used for paths starting with
+ * `"/public/images/"` and `"/public/"` will be used for all other requests
+ * that start with `"/public/"`.
+ *
+ * Note that routes ending in a slash (`"/"`) are considered a rooted subtree
+ * they will match any URLs for which they are a prefix of the full path. This
+ * also means a route of just `"/"` will match on all requests, not just ones
+ * whose path is exactly `"/"`.
+ *
+ * If a request is received whose path does not contain a trailing slash, and
+ * there are no matches for that path, but there is a registered route that
+ * matches the request path with a trailing slash, then the Router will
+ * redirect the request with an additional trailing slash.
+ *
+ * Routes can also start with a hostname which will restrict matches to
+ * requests coming from that hostname. Hostname-specific routes take precedence
+ * over other registered routes.
+ */
+export class Router {
+  #routeMap: Map<string, Handler> = new Map();
+  #orderedRoutes: string[] = [];
+  #hosts = false;
+
+  /**
+   * Determines if the given path needs a "/" appended to it.
+   *
+   * This occurs if there are no registered handlers for the path, but there is
+   * for the path + "/".
+   *
+   * @param {string} host The host to match against registered routes.
+   * @param {string} path The path to match against registered routes.
+   * @returns {boolean} Whether to redirect.
+   * @private
+   */
+  #shouldRedirect(host: string, path: string): boolean {
+    const routes = [path, `${host}${path}`];
+
+    for (const route of routes) {
+      if (this.#routeMap.has(route)) {
+        return false;
+      }
+    }
+
+    if (!path.length) {
+      return false;
+    }
+
+    for (const route of routes) {
+      if (this.#routeMap.has(`${route}/`)) {
+        return path.at(-1) !== "/";
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Determines if the given path needs a "/" appended to it.
+   *
+   * This occurs if there are no registered handlers for the path, but there is
+   * for the path + "/".
+   *
+   * If it is determined that a redirect is needed, a new URL is constructed
+   * with the updated path containing the trailing slash.
+   *
+   * @param {string} host The host to match against registered routes.
+   * @param {string} path The path to match against registered routes.
+   * @param {URL} url The request url.
+   * @returns {Object} Whether the handler should redirect, and if so, the redirect url.
+   * @private
+   */
+  #redirectToPathSlash(
+    host: string,
+    path: string,
+    url: URL,
+  ): { redirectUrl?: URL; redirect: boolean } {
+    if (!this.#shouldRedirect(host, path)) {
+      return { redirect: false };
+    }
+
+    const redirectUrl = new URL(url.toString());
+    path += "/";
+    redirectUrl.pathname = path;
+
+    return { redirectUrl, redirect: true };
+  }
+
+  /**
+   * Matches the route against registered routes.
+   *
+   * @param {string} route The route to match.
+   * @returns {Handler|undefined} The matched handler or undefined if there are no matches.
+   * @private
+   */
+  #match(route: string): Handler | undefined {
+    const handler = this.#routeMap.get(route);
+
+    if (handler) {
+      return handler;
+    }
+
+    for (const registeredRoute of this.#orderedRoutes) {
+      if (route.startsWith(registeredRoute)) {
+        return this.#routeMap.get(registeredRoute);
+      }
+    }
+
+    return;
+  }
+
+  /**
+   * Matches request host and path against registered routes and returns
+   * matching handlers.
+   *
+   * If there is no registered handler for the route a 404 "Not Found" response
+   * will be sent.
+   *
+   * @param {string} host The host to match against registered routes.
+   * @param {string} path The path to match against registered routes.
+   * @returns {Handler} The matched handler, or the "Not Found" handler if no matches are found.
+   * @private
+   */
+  #matchHandler(host: string, path: string): Handler {
+    let handler;
+
+    if (this.#hosts) {
+      handler = this.#match(`${host}${path}`);
+    }
+
+    handler ??= this.#match(path) ?? _notFoundHandler();
+
+    return handler as Handler;
+  }
+
+  /**
+   * Retrieves the handler based on the request method, host and path.
+   *
+   * @param {Request} request The HTTP request to handle.
+   * @returns {Handler} The matched handler for the request.
+   * @private
+   */
+  #getHandler(request: Request): Handler {
+    const requestUrl = new URL(request.url);
+
+    if (request.method === "CONNECT") {
+      const { redirect, redirectUrl } = this.#redirectToPathSlash(
+        requestUrl.host,
+        requestUrl.pathname,
+        requestUrl,
+      );
+
+      if (redirect) {
+        return _redirectHandler(
+          redirectUrl!,
+          Status.MovedPermanently,
+        );
+      }
+
+      const host = _getHost(request.headers, requestUrl);
+
+      return this.#matchHandler(host, requestUrl.pathname);
+    }
+
+    const hostname = _getHostname(request.headers, requestUrl);
+    const path = _getNormalizedPath(requestUrl.pathname);
+
+    const { redirect, redirectUrl } = this.#redirectToPathSlash(
+      hostname,
+      path,
+      requestUrl,
+    );
+
+    if (redirect) {
+      return _redirectHandler(redirectUrl!, Status.MovedPermanently);
+    }
+
+    if (path !== requestUrl.pathname) {
+      requestUrl.pathname = path;
+
+      return _redirectHandler(requestUrl, Status.MovedPermanently);
+    }
+
+    return this.#matchHandler(hostname, path);
+  }
+
+  /**
+   * The Router's handler for HTTP requests. For the given request it consults
+   * the method, host, and url to match against registered handlers, consumes
+   * the request and connection information and returns a response.
+   *
+   * If the url path is not in it's canonical form, the handler will redirect
+   * the request to the canonical path.
+   *
+   * If the host contains a port, it will be ignored when matching handlers
+   * except for CONNECT requests where the host is consumed unchanged.
+   *
+   * If there is no registered handler for the route a 404 "Not Found" response
+   * will be sent.
+   *
+   * @param {Request} request The HTTP request to handle.
+   * @param {ConnInfo} connInfo Information about the connection the request arrived on.
+   * @returns {Response|Promise<Response>} The response to the request.
+   */
+  handler(request: Request, connInfo: ConnInfo): Response | Promise<Response> {
+    const handler = this.#getHandler(request);
+
+    return handler(request, connInfo);
+  }
+
+  /**
+   * Registers the handler for the given route. If a handler already exists for
+   * the route then an error is thrown.
+   *
+   * @param {string} route The route to match HTTP requests to the provided handler.
+   * @param {Handler} handler The handler for individual HTTP requests.
+   * @throws {Deno.errors.Http} When an invalid route is used.
+   * @throws {Deno.errors.Http} When a handler already exists for the route.
+   */
+  handle(route: string, handler: Handler): void {
+    if (route === "") {
+      throw ERROR_INVALID_ROUTE;
+    }
+    if (this.#routeMap.has(route)) {
+      throw new Deno.errors.Http(`Route ${route} already registered`);
+    }
+
+    this.#routeMap.set(route, handler);
+
+    if (route.at(-1) === "/") {
+      const index = this.#orderedRoutes.findIndex((orderedRoute) =>
+        orderedRoute.length < route.length
+      );
+
+      this.#orderedRoutes.splice(index, 0, route);
+    }
+
+    if (route[0] !== "/") {
+      this.#hosts = true;
+    }
+  }
+}

--- a/http/router_test.ts
+++ b/http/router_test.ts
@@ -1,0 +1,237 @@
+import { Router } from "./router.ts";
+import type { ConnInfo } from "./native_server.ts";
+import { Status, STATUS_TEXT } from "./http_status.ts";
+import { assertEquals, assertThrows } from "../testing/asserts.ts";
+
+const mockConnInfo: ConnInfo = {
+  localAddr: { hostname: "0.0.0.0", port: 4505, transport: "tcp" },
+  remoteAddr: { hostname: "0.0.0.0", port: 4505, transport: "tcp" },
+};
+
+Deno.test("Router.handler should throw when passed an empty route", () => {
+  const router = new Router();
+
+  assertThrows(
+    () => router.handle("", () => new Response()),
+    Deno.errors.Http,
+    "Invalid route",
+  );
+});
+
+Deno.test("Router.handler should throw when passed a route that has already been registered", () => {
+  const route = "/test/route";
+  const router = new Router();
+  router.handle(route, () => new Response());
+
+  assertThrows(
+    () => router.handle(route, () => new Response()),
+    Deno.errors.Http,
+    `Route ${route} already registered`,
+  );
+});
+
+["/", "/path", "/path/"].forEach((path) => {
+  Deno.test(`Router will fallback to a 404 response if there is no registered handler for a path route '${path}'`, async () => {
+    const router = new Router();
+    const request = new Request(`http://0.0.0.0:4505${path}?qs=test#hash`);
+    const response = await router.handler(request, mockConnInfo);
+
+    assertEquals(
+      response,
+      new Response(STATUS_TEXT.get(Status.NotFound), {
+        headers: new Headers({
+          "content-type": "text/plain; charset=utf-8",
+          "x-content-type-options": "nosniff",
+        }),
+        status: Status.NotFound,
+      }),
+    );
+  });
+
+  Deno.test(`Router will fallback to a 404 response if there is no registered handler for a host + path route '0.0.0.1${path}'`, async () => {
+    const router = new Router();
+    router.handle(`0.0.0.1${path}`, () => new Response());
+
+    const request = new Request(`http://0.0.0.0:4505${path}?qs=test#hash`);
+    const response = await router.handler(request, mockConnInfo);
+
+    assertEquals(
+      response,
+      new Response(STATUS_TEXT.get(Status.NotFound), {
+        headers: new Headers({
+          "content-type": "text/plain; charset=utf-8",
+          "x-content-type-options": "nosniff",
+        }),
+        status: Status.NotFound,
+      }),
+    );
+  });
+
+  Deno.test(`Router will match on registered path route '${path}'`, async () => {
+    const expectedResponse = new Response("test-response");
+    const router = new Router();
+    router.handle(path, () => expectedResponse);
+
+    const request = new Request(`http://0.0.0.0:4505${path}?qs=test#hash`);
+    const response = await router.handler(request, mockConnInfo);
+
+    assertEquals(response, expectedResponse);
+  });
+
+  Deno.test(`Router will match on registered host + path route '0.0.0.1${path}'`, async () => {
+    const expectedResponse = new Response("test-response");
+    const router = new Router();
+    router.handle(`0.0.0.1${path}`, () => expectedResponse);
+
+    const request = new Request(`http://0.0.0.1:4505${path}?qs=test#hash`);
+    const response = await router.handler(request, mockConnInfo);
+
+    assertEquals(response, expectedResponse);
+  });
+
+  Deno.test(`Router will match on registered host header + path route '0.0.0.1${path}'`, async () => {
+    const expectedResponse = new Response("test-response");
+    const router = new Router();
+    router.handle(`0.0.0.1${path}`, () => expectedResponse);
+
+    const request = new Request(`http://0.0.0.1:4505${path}?qs=test#hash`, {
+      headers: new Headers({ host: "0.0.0.1" }),
+    });
+    const response = await router.handler(request, mockConnInfo);
+
+    assertEquals(response, expectedResponse);
+  });
+});
+
+Deno.test("Router registered root path '/' matches all unmatched routes", () => {
+  const expectedResponse = new Response("test-response");
+  const router = new Router();
+  router.handle("/", () => expectedResponse);
+
+  [
+    "/",
+    "/path",
+    "/path/",
+  ].forEach(async (path) => {
+    const request = new Request(`http://0.0.0.1:4505${path}?qs=test#hash`);
+    const response = await router.handler(request, mockConnInfo);
+
+    assertEquals(response, expectedResponse);
+  });
+});
+
+Deno.test("Router registered root host + path '0.0.0.1/' matches all unmatched routes for the host '0.0.0.1'", () => {
+  const expectedResponse = new Response("test-response");
+  const router = new Router();
+  router.handle("0.0.0.1/", () => expectedResponse);
+
+  [
+    "/",
+    "/path",
+    "/path/",
+  ].forEach(async (path) => {
+    const request = new Request(`http://0.0.0.1:4505${path}?qs=test#hash`);
+    const response = await router.handler(request, mockConnInfo);
+
+    assertEquals(response, expectedResponse);
+  });
+
+  [
+    "/",
+    "/path",
+    "/path/",
+  ].forEach(async (path) => {
+    const request = new Request(`http://0.0.0.0:4505${path}?qs=test#hash`);
+    const response = await router.handler(request, mockConnInfo);
+
+    assertEquals(
+      response,
+      new Response(STATUS_TEXT.get(Status.NotFound), {
+        headers: new Headers({
+          "content-type": "text/plain; charset=utf-8",
+          "x-content-type-options": "nosniff",
+        }),
+        status: Status.NotFound,
+      }),
+    );
+  });
+});
+
+Deno.test("Router longer registered rooted subtrees take precedent over shorter rooted subtrees for matching path routes", () => {
+  const expectedResponse = new Response("test-response");
+  const router = new Router();
+  router.handle("/", () => new Response());
+  router.handle("/path/", () => new Response());
+  router.handle("/path/longest/", () => expectedResponse);
+  router.handle("/path/notrootedsubtree", () => new Response());
+
+  ["/", "/path", "/path/"].forEach(async (path) => {
+    const request = new Request(
+      `http://0.0.0.0:4505/path/longest${path}?qs=test#hash`,
+    );
+    const response = await router.handler(request, mockConnInfo);
+
+    assertEquals(response, expectedResponse);
+  });
+});
+
+Deno.test("Router longer registered rooted subtrees take precedent over shorter rooted subtrees for matching host + path routes", () => {
+  const expectedResponse = new Response("test-response");
+  const router = new Router();
+  router.handle("0.0.0.1/", () => new Response());
+  router.handle("0.0.0.1/path/", () => new Response());
+  router.handle("0.0.0.1/path/longest/", () => expectedResponse);
+  router.handle("0.0.0.1/path/notrootedsubtree", () => new Response());
+  router.handle("/", () => new Response());
+  router.handle("/path/", () => new Response());
+  router.handle("/path/longest/", () => new Response());
+  router.handle("/path/notrootedsubtree", () => new Response());
+
+  ["/", "/path", "/path/"].forEach(async (path) => {
+    const request = new Request(
+      `http://0.0.0.1:4505/path/longest${path}?qs=test#hash`,
+    );
+    const response = await router.handler(request, mockConnInfo);
+
+    assertEquals(response, expectedResponse);
+  });
+});
+
+Deno.test("Router paths without trailing slash with no matches that would match with a trailing slash are redirected to add the trailing slash", async () => {
+  const url = "http://0.0.0.0:4505/path?qs=test#hash";
+
+  const router = new Router();
+  router.handle("/", () => new Response());
+  router.handle("/path/", () => new Response());
+
+  const request = new Request(url);
+  const response = await router.handler(request, mockConnInfo);
+
+  assertEquals(
+    response,
+    new Response(null, {
+      headers: new Headers({
+        location: "http://0.0.0.0:4505/path/?qs=test#hash",
+      }),
+      status: Status.MovedPermanently,
+    }),
+  );
+});
+
+Deno.test("Router non-normalized paths should be redirected to their normalized form", async () => {
+  const urlBase = "http://0.0.0.0:4505/path/";
+
+  const router = new Router();
+  router.handle("/path/", () => new Response());
+
+  const request = new Request(`${urlBase}../path//.?qs=test#hash`);
+  const response = await router.handler(request, mockConnInfo);
+
+  assertEquals(
+    response,
+    new Response(null, {
+      headers: new Headers({ location: `${urlBase}?qs=test#hash` }),
+      status: Status.MovedPermanently,
+    }),
+  );
+});

--- a/http/testdata/simple_router.ts
+++ b/http/testdata/simple_router.ts
@@ -1,0 +1,21 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// A simple Router example with the following routes:
+//   1. `/` - responds with status code 200.
+//   2. `/admin/` - responds with status code 403.
+
+import { listenAndServe } from "../native_server.ts";
+import { Router } from "../router.ts";
+
+const addr = "0.0.0.0:4506";
+
+const router = new Router();
+
+router.handle("/", () => new Response("Hello Deno!", { status: 200 }));
+router.handle("/admin/", () => new Response("Restricted!", { status: 403 }));
+
+console.log(`Simple server listening on http://${addr}`);
+
+await listenAndServe(
+  addr,
+  (request, connInfo) => router.handler(request, connInfo),
+);


### PR DESCRIPTION
**WIP**

Following #1128, this implements a simple router / request multiplexer for the native HTTP server, inspired by the golang `net/http` std library's `ServeMux`.

REF:
- https://github.com/denoland/deno_std/pull/1128
- https://pkg.go.dev/net/http#ServeMux